### PR TITLE
feat (DOCS-CODE-001): [authz] [API] [tutorial] annotate canonical minimal api code

### DIFF
--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -1,26 +1,39 @@
+// <ms_docref_import_types>
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Identity.Web;
+// </ms_docref_import_types>
 
 var builder = WebApplication.CreateBuilder(args);
 
+// <ms_docref_add_msal>
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
+// </ms_docref_add_msal>
+// <ms_docref_add_default_authz_policies>
 builder.Services.AddAuthorization();
+// </ms_docref_add_default_authz_policies>
 
 var app = builder.Build();
 
 app.UseHttpsRedirection();
 
+
+// <ms_docref_enable_authn_capabilities>
 app.UseAuthentication();
+// </ms_docref_enable_authn_capabilities>
+// <ms_docref_enable_authz_capabilities>
 app.UseAuthorization();
+// </ms_docref_enable_authz_capabilities>
 
 var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 };
 
+
+// <ms_docref_protect_endpoint>
 app.MapGet("/weatherforecast", [Authorize] () =>
 {
     var forecast =  Enumerable.Range(1, 5).Select(index =>
@@ -34,6 +47,7 @@ app.MapGet("/weatherforecast", [Authorize] () =>
     return forecast;
 })
 .WithName("GetWeatherForecast");
+// </ms_docref_protect_endpoint>
 
 app.Run();
 

--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -1,5 +1,4 @@
 // <ms_docref_import_types>
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Identity.Web;

--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -9,7 +9,11 @@ using Microsoft.Identity.Web;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
-builder.Services.AddAuthorization();
+builder.Services.AddAuthorization(config =>
+{
+    config.AddPolicy("AuthZPolicy", policyBuilder =>
+        policyBuilder.Requirements.Add(new ScopeAuthorizationRequirement() { RequiredScopesConfigurationKey = $"AzureAd:Scopes" }));
+});
 // </ms_docref_add_msal>
 
 // <ms_docref_enable_authz_capabilities>
@@ -24,7 +28,7 @@ var summaries = new[]
 };
 
 // <ms_docref_protect_endpoint>
-app.MapGet("/weatherforecast", [Authorize] () =>
+app.MapGet("/weatherforecast", [Authorize (Policy="AuthZPolicy")] () =>
 {
     var forecast =  Enumerable.Range(1, 5).Select(index =>
         new WeatherForecast

--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -27,15 +27,15 @@ var summaries = new[]
 };
 
 // <ms_docref_protect_endpoint>
-app.MapGet("/weatherforecast", [Authorize (Policy="AuthZPolicy")] () =>
+app.MapGet("/weatherforecast", [Authorize(Policy = "AuthZPolicy")] () =>
 {
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateTime.Now.AddDays(index),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+       new WeatherForecast
+       (
+           DateTime.Now.AddDays(index),
+           Random.Shared.Next(-20, 55),
+           summaries[Random.Shared.Next(summaries.Length)]
+       ))
         .ToArray();
     return forecast;
 })

--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -17,7 +17,6 @@ builder.Services.AddAuthorization();
 
 WebApplication app = builder.Build();
 
-app.UseHttpsRedirection();
 
 // <ms_docref_enable_authn_capabilities>
 app.UseAuthentication();

--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -5,23 +5,16 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Identity.Web;
 // </ms_docref_import_types>
 
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-
 // <ms_docref_add_msal>
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddMicrosoftIdentityWebApi(builder.Configuration.GetSection("AzureAd"));
-// </ms_docref_add_msal>
-// <ms_docref_add_default_authz_policies>
 builder.Services.AddAuthorization();
-// </ms_docref_add_default_authz_policies>
+// </ms_docref_add_msal>
 
-WebApplication app = builder.Build();
-
-
-// <ms_docref_enable_authn_capabilities>
-app.UseAuthentication();
-// </ms_docref_enable_authn_capabilities>
 // <ms_docref_enable_authz_capabilities>
+WebApplication app = builder.Build();
+app.UseAuthentication();
 app.UseAuthorization();
 // </ms_docref_enable_authz_capabilities>
 

--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -19,7 +19,6 @@ var app = builder.Build();
 
 app.UseHttpsRedirection();
 
-
 // <ms_docref_enable_authn_capabilities>
 app.UseAuthentication();
 // </ms_docref_enable_authn_capabilities>
@@ -31,7 +30,6 @@ var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 };
-
 
 // <ms_docref_protect_endpoint>
 app.MapGet("/weatherforecast", [Authorize] () =>

--- a/src/protect-api/Program.cs
+++ b/src/protect-api/Program.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Identity.Web;
 // </ms_docref_import_types>
 
-var builder = WebApplication.CreateBuilder(args);
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 // <ms_docref_add_msal>
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -15,7 +15,7 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 // </ms_docref_add_default_authz_policies>
 
-var app = builder.Build();
+WebApplication app = builder.Build();
 
 app.UseHttpsRedirection();
 

--- a/src/protect-api/README.md
+++ b/src/protect-api/README.md
@@ -1,19 +1,19 @@
-# Protected ASP.NET Core minimal API | Microsoft identity platform
+# Protected ASP.NET Core minimal web API | Microsoft identity platform
 
 The sample code provided here has been created using minimal web API in ASP.NET Core 6.0, and slightly modified to be protected for a single organization using [ASP.NET Core Identity](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-6.0) that interacts with [Microsoft Authentication Library (MSAL)](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-overview).  In other words, a very minimalist web api is secured by adding an authorization layer before user requests can reach protected resources.  At this point it is expected that the user sign-in had already happened, so api calls can be made in the name of the signed-in user. For that to be possible a token containing user's information is being sent in the request headers and used in the authorization process.
 
 ```output
-┌────────────────────────┐                               ┌─────────────────────────────┐
-│                        │                               │                             │
-│   ASP.NET Core 6       │        Http Request           │  ASP.NET Core 6             │
-│                        ├──────────────────────────────►│                             │
-│   Protected Web App    │  Authorization Bearer 1NS...  │  Protected Minimal Web Api  │
-│                        │                               │                             │
-└────────────────────────┘                               └─────────────────────────────┘
+┌──────────────────────────────────┐                               ┌─────────────────────────────┐
+│                                  │                               │                             │
+│   ASP.NET Core 6                 │        Http Request           │  ASP.NET Core 6             │
+│                                  ├──────────────────────────────►│                             │
+│   Web app that signs in users    │  Authorization Bearer 1NS...  │  Protected Minimal web Api  │
+│                                  │  with access_as_user scope    │                             │
+└──────────────────────────────────┘                               └─────────────────────────────┘
 
 Scenario:
 
-A protected web app allows users to sign in, it enables the possibility of acquiring and validating their tokens.
+An (ASP.NET Core) web app that allows users to sign in enables the possibility of acquiring and validating their tokens for specific audiences and scopes.
 
 Later the web app can make calls to protected Apis in the name of the signed-in users.
 ```
@@ -24,9 +24,9 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
 
 1. [Download .NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
 
-## Register the web API application in your Azure Active Directory
+## Register the web API application in your Azure Active Directory (Azure AD)
 
-1. Register a new Azure AD App
+1. Register a new Azure AD app
 
    ```bash
    AZURE_AD_APP_DETAILS_MINIMAL_API=$(az ad app create --display-name "active-directory-dotnet-minimal-api-aspnetcore" -o json) && \
@@ -61,7 +61,7 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
    EOF
    ```
 
-1. Set the api uri and the `access_as_user` scope
+1. Set a global unique URI that identify the web API and add the `access_as_user` scope
 
    ```bash
    az ad app update --id $AZURE_AD_APP_CLIENT_ID_MINIMAL_API --identifier-uris "api://${AZURE_AD_APP_CLIENT_ID_MINIMAL_API}" --set oauth2Permissions=@access_as_user_scope.json

--- a/src/protect-api/README.md
+++ b/src/protect-api/README.md
@@ -7,18 +7,18 @@ The sample code provided here has been created using minimal web API in ASP.NET 
 │                        │                               │                             │
 │   ASP.NET Core 6       │        Http Request           │  ASP.NET Core 6             │
 │                        ├──────────────────────────────►│                             │
-│   Proctected Web App   │  Authorization Bearer 1NS...  │  Protected Minimal Web Api  │
+│   Protected Web App    │  Authorization Bearer 1NS...  │  Protected Minimal Web Api  │
 │                        │                               │                             │
 └────────────────────────┘                               └─────────────────────────────┘
 
 Scenario:
 
-A protected web app allows users to sign in, it enables the possiblity of acquiring and validating their tokens.
+A protected web app allows users to sign in, it enables the possibility of acquiring and validating their tokens.
 
 Later the web app can make calls to protected Apis in the name of the signed-in users.
 ```
 
-:link: For more information about how to proctect your projects, please let's take a look at https://docs.microsoft.com/en-us/azure/active-directory/develop/sample-v2-code. To know more about how this sample has been generated, please visit https://docs.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?view=aspnetcore-6.0&tabs=visual-studio-code
+:link: For more information about how to protect your projects, please let's take a look at https://docs.microsoft.com/en-us/azure/active-directory/develop/sample-v2-code. To know more about how this sample has been generated, please visit https://docs.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?view=aspnetcore-6.0&tabs=visual-studio-code
 
 ## Prerequisites
 
@@ -83,7 +83,7 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
 
 ## Configure the web API
 
-1. Create the `appsettings.json` file with the Azure AD app comfiguration
+1. Create the `appsettings.json` file with the Azure AD app configuration
 
    ```bash
    cat > appsettings.json <<EOF
@@ -121,7 +121,7 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
    curl -X GET https://localhost:5001/weatherforecast -ki
    ```
 
-   :book: Since the request is sent without a Bearer Token, it is expected to receive an Unauthorized reponse `401`. The web API is now protected
+   :book: Since the request is sent without a Bearer Token, it is expected to receive an Unauthorized response `401`. The web API is now protected
 
 ## Clean up
 

--- a/src/protect-api/README.md
+++ b/src/protect-api/README.md
@@ -91,7 +91,8 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
      "AzureAd": {
        "Instance": "https://login.microsoftonline.com/",
        "ClientId": "${AZURE_AD_APP_CLIENT_ID_MINIMAL_API}",
-       "TenantId": "$(az account show --query tenantId --output tsv)"
+       "TenantId": "$(az account show --query tenantId --output tsv)",
+       "Scopes": "access_as_user"
      },
      "Logging": {
        "LogLevel": {

--- a/src/protect-api/README.md
+++ b/src/protect-api/README.md
@@ -8,7 +8,7 @@ The sample code provided here has been created using minimal web API in ASP.NET 
 │   ASP.NET Core 6                 │        Http Request           │  ASP.NET Core 6             │
 │                                  ├──────────────────────────────►│                             │
 │   Web app that signs in users    │  Authorization Bearer 1NS...  │  Protected Minimal web Api  │
-│                                  │  with access_as_user scope    │                             │
+│                                  │  with forescast.read scope    │                             │
 └──────────────────────────────────┘                               └─────────────────────────────┘
 
 Scenario:
@@ -40,10 +40,10 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
    az ad app update --id $AZURE_AD_APP_CLIENT_ID_MINIMAL_API --set oauth2Permissions="$AZURE_AD_APP_USER_IMPERSONATION_SCOPE"
    ```
 
-1. Create a new manifest scope for `access_as_user`
+1. Create a new manifest scope for `forescast.read`
 
    ```bash
-   cat > access_as_user_scope.json <<EOF
+   cat > forescast.read.json <<EOF
    [
      {
        "adminConsentDescription": "Allows the app to access Minimal Api (active-directory-dotnet-minimal-api-aspnetcore) as the signed-in user.",
@@ -55,16 +55,16 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
        "type": "User",
        "userConsentDescription": "Allow the application to access Minimal (active-directory-dotnet-minimal-aspnetcore) on your behalf.",
        "userConsentDisplayName": "Access Minimal Api (active-directory-dotnet-minimal-aspnetcore)",
-       "value": "access_as_user"
+       "value": "forescast.read"
      }
    ]
    EOF
    ```
 
-1. Set a global unique URI that identify the web API and add the `access_as_user` scope
+1. Set a global unique URI that identify the web API and add the `forescast.read` scope
 
    ```bash
-   az ad app update --id $AZURE_AD_APP_CLIENT_ID_MINIMAL_API --identifier-uris "api://${AZURE_AD_APP_CLIENT_ID_MINIMAL_API}" --set oauth2Permissions=@access_as_user_scope.json
+   az ad app update --id $AZURE_AD_APP_CLIENT_ID_MINIMAL_API --identifier-uris "api://${AZURE_AD_APP_CLIENT_ID_MINIMAL_API}" --set oauth2Permissions=@forescast.read.json
    ```
 
 ## Scaffold the web API by using the ASP.NET Core Minimal Api project template
@@ -92,7 +92,7 @@ Later the web app can make calls to protected Apis in the name of the signed-in 
        "Instance": "https://login.microsoftonline.com/",
        "ClientId": "${AZURE_AD_APP_CLIENT_ID_MINIMAL_API}",
        "TenantId": "$(az account show --query tenantId --output tsv)",
-       "Scopes": "access_as_user"
+       "Scopes": "forescast.read"
      },
      "Logging": {
        "LogLevel": {


### PR DESCRIPTION
closes: #508094, #1651007

## WHY

Microsoft Identity Platform tutorials require some special in-code-annotations. This first PR is just an exploration over the process of adding them, and a medium to ignite the discussion for the expected ones in this very specific tutorial.   

## WHAT Changed?

add on top of the `Protected Minimal Api` in-code-annotation that enable the content dev team to create prescribed steps in our tutorials. 

## HOW to test?

All expected annotations should in be in place while reading the `Program.cs` file.