### PR TITLE
feat (DOCS-CODE-016): [authN] [sign-in] [tutorial] annotate canonical webapp identity sample for user sign-in using in ASP.NET Core 6 Razor

### DIFF
--- a/src/sign-in-webapp/Program.cs
+++ b/src/sign-in-webapp/Program.cs
@@ -1,25 +1,38 @@
+// <ms_docref_import_types>
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.UI;
+// </ms_docref_import_types>
 
+// <ms_docref_add_msal>
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 IEnumerable<string>? initialScopes = builder.Configuration["DownstreamApi:Scopes"]?.Split(' ');
+
 builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"))
         .EnableTokenAcquisitionToCallDownstreamApi(initialScopes)
             .AddDownstreamWebApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
             .AddInMemoryTokenCaches();
+// </ms_docref_add_msal>
+
+// <ms_docref_add_default_authz_policies>
 builder.Services.AddAuthorization(options =>
 {
     options.FallbackPolicy = options.DefaultPolicy;
 });
+// </ms_docref_add_default_authz_policies>
 
+// <ms_docref_add_default_controller_for_sign-in-out>
 builder.Services.AddRazorPages()
     .AddMicrosoftIdentityUI();
+// </ms_docref_add_default_controller_for_sign-in-out>
 
+// <ms_docref_enable_authz_capabilities>
 WebApplication app = builder.Build();
+
 app.UseAuthentication();
 app.UseAuthorization();
+// </ms_docref_enable_authz_capabilities>
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();


### PR DESCRIPTION
closes: #508064, #1652433

## WHY

Microsoft Identity Platform tutorials require some special in-code-annotations. This first PR is the one adding those required for the `DOCS-CODE-016` tutorial.

## WHAT Changed?

add on top of the canonical webapp identity sample for user sign-in using in ASP.NET Core 6 Razor in-code-annotation that enable the content dev team to create prescribed steps in our tutorials.

## HOW to test?

All expected annotations should in be in place while reading the `Program.cs` file.
